### PR TITLE
Revert "Update personas.sketchplugin"

### DIFF
--- a/personas.sketchplugin
+++ b/personas.sketchplugin
@@ -41,7 +41,7 @@ function getUser() {
 function getUsers(count) {
 	var request = NSMutableURLRequest.new();
 	[request setHTTPMethod:@"GET"];
-	var queryString = "http://api.randomuser.me?sketch=true&nat=us&results=" + count;
+	var queryString = "http://api.randomuser.me?nat=us&results=" + count;
 	[request setURL:[NSURL URLWithString:queryString]];
 
 	var error = NSError.new();


### PR DESCRIPTION
Reverts nolastan/Sketch-Personas#7

@keitharm It seems that adding `sketch=true` reverts the API to 0.4 and breaks the plugin.
